### PR TITLE
fix: record length from body object

### DIFF
--- a/body.go
+++ b/body.go
@@ -25,7 +25,7 @@ func parseBodySelect(body interface{}) (bs BodySelect) {
 		}
 
 		// レコード
-		recordLen := len(body.([]interface{})[0].([]interface{})) - 2
+		recordLen := len(o.([]interface{})) - 2
 		sr.Records = make([]interface{}, 0, recordLen)
 		for i := 0; i < recordLen; i++ {
 			index := i + 2

--- a/body.go
+++ b/body.go
@@ -25,7 +25,7 @@ func parseBodySelect(body interface{}) (bs BodySelect) {
 		}
 
 		// レコード
-		recordLen := len(o.([]interface{})[2].([]interface{}))
+		recordLen := len(body.([]interface{})[0].([]interface{})) - 2
 		sr.Records = make([]interface{}, 0, recordLen)
 		for i := 0; i < recordLen; i++ {
 			index := i + 2


### PR DESCRIPTION
`o`のレコード値が、body[0]の配列数と同義のため、oレコード全体から`-2` ヘッダカラム情報分
除いたものを実データの配列数でセット